### PR TITLE
Make "invert_mouse" setting actually functional

### DIFF
--- a/UnityProject/Assets/Scripts/AimScript.cs
+++ b/UnityProject/Assets/Scripts/AimScript.cs
@@ -1307,7 +1307,7 @@ public class AimScript:MonoBehaviour{
     	
     	sensitivity_x = Preferences.mouse_sensitivity * 10.0f;
     	sensitivity_y = Preferences.mouse_sensitivity * 10.0f;
-    	if(PlayerPrefs.GetInt("mouse_invert", 0) == 1){
+    	if(PlayerPrefs.GetInt("invert_mouse", 0) == 1){
     		sensitivity_y = -Mathf.Abs(sensitivity_y);
     	} else {
     		sensitivity_y = Mathf.Abs(sensitivity_y);

--- a/UnityProject/Assets/Scripts/optionsmenuscript.cs
+++ b/UnityProject/Assets/Scripts/optionsmenuscript.cs
@@ -207,7 +207,7 @@ public class optionsmenuscript : MonoBehaviour {
         PlayerPrefs.SetFloat("mouse_sensitivity", 0.2f);
         PlayerPrefs.SetFloat("gun_distance", 1f);
         PlayerPrefs.SetInt("lock_gun_to_center", 0);
-        PlayerPrefs.SetInt("mouse_invert", 0);
+        PlayerPrefs.SetInt("invert_mouse", 0);
         PlayerPrefs.SetInt("toggle_crouch", 1);
 
         PlayerPrefs.SetInt("vsync", 0);


### PR DESCRIPTION
It is setting: `invert_mouse` but it was observing: `mouse_invert`